### PR TITLE
removing unnecessary export mod.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,4 +28,4 @@ const open = url => new Promise((resolve, reject) => {
   }
 });
 
-module.exports = { open };
+module.exports = open;


### PR DESCRIPTION
# Description

*Depends on:*
- None

*Description*
it's ultimately useless to export it as { open }. you'd need to access the inner property which is not really important.
```js
//This
const open = require("out-url") // ability to give it a dynamic name while a presistent type functionality
open("")
require("out-url")("")

//Current
const {open} = require("out-url")
open("")
require("out-url").open("")
```



# Steps to test
1. require -> ```const open = require("out-url")```
2. use -> ```open("")```
3. direct use -> ```require("out-url")("")```


