### PR TITLE
Add type definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
-declare function open(server: string): Promise<void>;
+declare function open(url: string): Promise<void>;
 
 export { open };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare function open(server: string): Promise<void>;
+
+export { open };


### PR DESCRIPTION
# Description

Add type definition file for Typescript projects in order to use well-typed `open` function.

Answering questions from [another PR](https://github.com/azhar22k/ourl/pull/5#pullrequestreview-628583935):

> How to test this change?

I've placed this type definition into working project right into `out-url` module and made sure:
1. new types are correctly recognized with Typescript engine
2. existing usages keep working as they were previously written for original `open` package
3. tests are passed (TS+Jest engine)

> This project does not have any babel compiling enabled, will it work without it?

Yes, `.d.ts` is just a definition file, it doesn't require compiling because definition files compile to nothing. It will be used with other TS projects as a way to provide types when using `open` function there. No any runtime functionality is affected.

> Instead of this would be a better approach to rewrite this project in type script?

Both options work. Rewriting to Typescript makes sense in terms of further supporting this package as a pure TS project. So it's up to whoever contributes to this. I suppose there won't be any noticeable changes and no need to turn this into full-fledged TS project.