### PR TITLE
Fix sanitization on Windows when opening URLs with query strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,16 @@ const commands = () => {
 
 const open = async (url) => {
   const [command, args = []] = commands();
+
+  // encode url and replace & with ^& for windows
+  url = encodeURI(url);
+  if (process.platform === 'win32') {
+    url = url.replaceAll('&', '^&');
+  }
+
   execFileSync(
     command,
-    [...args, encodeURI(url)],
+    [...args, url],
   );
 };
 


### PR DESCRIPTION
# Description
I've added a call to `.replaceAll` to replace all instances of `&` with `^&` in the encoded URL. Simply encoding the URL using `encodeURI` doesn't change it, and the error is still there (at least on my machine.

*Depends on:*
- [& in url cause issue on windows (#7)](https://github.com/azhar22k/ourl/issues/7)